### PR TITLE
specify required PostgreSQL versions (>= 9.2) in META.json

### DIFF
--- a/META.json
+++ b/META.json
@@ -28,5 +28,12 @@
    "meta-spec": {
       "version": "1.0.0",
       "url": "http://pgxn.org/meta/spec.txt"
-   }
+   },
+   "prereqs": {
+      "runtime": {
+         "requires": {
+            "PostgreSQL": "9.2.0"
+         }
+      }
+   },
 }


### PR DESCRIPTION
Without the prerequisities specified in the META.json specfile, pgxnclient can't identify which PostgreSQL versions is the extension compatible with. That results in failures like this:

http://pgxn-tester.org/results/1462d265-2166-45e9-92f7-b012906fb621

because the extension uses FDW routines introduced in 9.2.