### PR TITLE
#29 PostgreSQL ability to compile with 9.6 beta3

### DIFF
--- a/src/www_fdw.c
+++ b/src/www_fdw.c
@@ -627,7 +627,10 @@ www_get_foreign_paths(PlannerInfo *root,
 
     /* Create a ForeignPath node and add it as only possible path */
     add_path(baserel, (Path *)
-             create_foreignscan_path(root, baserel,
+            create_foreignscan_path(root, baserel,
+#if PG_VERSION_NUM >= 90600
+                                     NULL, /* PathTarget */
+#endif
                                      baserel->rows,
                                      startup_cost,
                                      total_cost,


### PR DESCRIPTION
This is just to make www_fdw be able to compile against 9.6beta3.  I am getting a crash sometimes in both 9.5 and 9.6, so I think that's a separate issue.