### PR TITLE
Authorization header for www_fdw

### DIFF
--- a/sql/www_fdw.sql
+++ b/sql/www_fdw.sql
@@ -23,7 +23,7 @@ CREATE TYPE WWWFdwOptions AS (
 	ssl_key text,
 	cainfo text,
 	proxy text,
-	cookie text
+	cookie text,
         username text,
         password text
 );

--- a/sql/www_fdw.sql
+++ b/sql/www_fdw.sql
@@ -24,6 +24,8 @@ CREATE TYPE WWWFdwOptions AS (
 	cainfo text,
 	proxy text,
 	cookie text
+        username text,
+        password text
 );
 -- type needed for returning post options in serialize_request_callback
 CREATE TYPE WWWFdwPostParameters AS (

--- a/src/www_fdw.c
+++ b/src/www_fdw.c
@@ -901,7 +901,7 @@ serialize_list_separator_callback_json) );
         datum = GetAttributeByName(rpost_tuple_header, "data", &isnull);
         if(!isnull)
             appendStringInfoString(&post->data, TextDatumGetCString(datum));
-
+        
         datum = GetAttributeByName(rpost_tuple_header, "content_type", &isnull);
         resetStringInfo(&post->content_type);
         if(!isnull)
@@ -1782,7 +1782,7 @@ www_begin(ForeignScanState *node, int eflags)
     {
         /* call specified callback for forming request */
         initStringInfo(&post.data);
-        initStringInfo(&post.content_type);
+        initStringInfo(&post.content_type);        
         serialize_request_with_callback(opts, opts_type, opts_value, node, &url, &post);
     }
     else
@@ -1802,7 +1802,8 @@ www_begin(ForeignScanState *node, int eflags)
     }
     if ( opts->password )
     {
-        curl_easy_setopt(curl, CURLOPT_PASSWORD,  opts->password );
+        curl_easy_setopt(curl, CURLOPT_PASSWORD, opts->password );
+        curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
     }
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_error_buffer);
 
@@ -2248,6 +2249,8 @@ get_options(Oid foreigntableid, WWW_fdw_options *opts)
     opts->cainfo           = NULL;
     opts->proxy            = NULL;
     opts->cookie           = NULL;
+    opts->username         = NULL;
+    opts->password         = NULL;
 
     /* Loop through the options, and get the server/port */
     foreach(lc, options)
@@ -2319,6 +2322,12 @@ get_options(Oid foreigntableid, WWW_fdw_options *opts)
 
         if (strcmp(def->defname, "cookie") == 0)
             opts->cookie = defGetString(def);
+        
+        if (strcmp(def->defname, "username") == 0)
+            opts->username = defGetString(def);
+        
+        if (strcmp(def->defname, "password") == 0)
+            opts->password = defGetString(def);
     }
 
     /* Default values, if required */

--- a/src/www_fdw.c
+++ b/src/www_fdw.c
@@ -1807,6 +1807,11 @@ www_begin(ForeignScanState *node, int eflags)
         {
             curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_opts);
         }
+        
+        /* Deleting */
+        if ( 0 == strcmp(opts->method_select, "DELETE")) {
+            curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE" );
+        }
 
 	/* prepare parsers */
 	if( 0 == strcmp(opts->response_type, "json") )

--- a/src/www_fdw.c
+++ b/src/www_fdw.c
@@ -901,7 +901,7 @@ serialize_list_separator_callback_json) );
         datum = GetAttributeByName(rpost_tuple_header, "data", &isnull);
         if(!isnull)
             appendStringInfoString(&post->data, TextDatumGetCString(datum));
-        
+
         datum = GetAttributeByName(rpost_tuple_header, "content_type", &isnull);
         resetStringInfo(&post->content_type);
         if(!isnull)
@@ -1782,7 +1782,7 @@ www_begin(ForeignScanState *node, int eflags)
     {
         /* call specified callback for forming request */
         initStringInfo(&post.data);
-        initStringInfo(&post.content_type);        
+        initStringInfo(&post.content_type);
         serialize_request_with_callback(opts, opts_type, opts_value, node, &url, &post);
     }
     else

--- a/src/www_fdw.c
+++ b/src/www_fdw.c
@@ -80,7 +80,8 @@ static struct WWW_fdw_option valid_options[] =
     { "cainfo", ForeignServerRelationId },
     { "proxy",  ForeignServerRelationId },
     { "cookie",  ForeignServerRelationId },
-
+    { "username",  ForeignServerRelationId },
+    { "password",  ForeignServerRelationId },
     /* Sentinel */
     { NULL,            InvalidOid }
 };
@@ -110,6 +111,8 @@ typedef struct    WWW_fdw_options
     char*   cainfo;
     char*   proxy;
     char*   cookie;
+    char*   username;
+    char*   password;
 } WWW_fdw_options;
 
 typedef struct Reply
@@ -236,6 +239,8 @@ www_fdw_validator(PG_FUNCTION_ARGS)
     char        *cainfo        = NULL;
     char        *proxy         = NULL;
     char        *cookie        = NULL;
+    char        *username      = NULL;
+    char        *password      = NULL;
 
     d("www_fdw_validator routine");
 
@@ -322,6 +327,8 @@ www_fdw_validator(PG_FUNCTION_ARGS)
         if(parse_parameter("cainfo", &cainfo, def)) continue;
         if(parse_parameter("proxy", &proxy, def)) continue;
         if(parse_parameter("cookie", &cookie, def)) continue;
+        if(parse_parameter("username", &username, def)) continue;
+        if(parse_parameter("password", &password, def)) continue;
     }
 
     PG_RETURN_VOID();
@@ -1418,7 +1425,9 @@ get_www_fdw_options(WWW_fdw_options *opts, Oid *opts_type, Datum *opts_value)
         opts->ssl_key,
         opts->cainfo,
         opts->proxy,
-        opts->cookie
+        opts->cookie,
+        opts->username,
+        opts->password
     };
     TupleDesc        tuple_desc;
     AttInMetadata*    aim;
@@ -1787,6 +1796,14 @@ www_begin(ForeignScanState *node, int eflags)
     curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_URL, url.data);
     curl_easy_setopt(curl, CURLOPT_USERAGENT, opts->request_user_agent);
+    if ( opts->username ) 
+    {
+        curl_easy_setopt(curl, CURLOPT_USERNAME,  opts->username );
+    }
+    if ( opts->password )
+    {
+        curl_easy_setopt(curl, CURLOPT_PASSWORD,  opts->password );
+    }
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_error_buffer);
 
     if(opts->request_user_header)

--- a/src/www_fdw.c
+++ b/src/www_fdw.c
@@ -66,6 +66,7 @@ static struct WWW_fdw_option valid_options[] =
 	{ "method_update",	ForeignServerRelationId },
 
 	{ "request_user_agent",	ForeignServerRelationId },
+        { "request_user_header",ForeignServerRelationId },
 	{ "request_serialize_callback",	ForeignServerRelationId },
 	{ "request_serialize_type",	ForeignServerRelationId },
 	{ "request_serialize_human_readable",	ForeignServerRelationId },
@@ -97,6 +98,7 @@ typedef struct	WWW_fdw_options
 	char*	method_delete;
 	char*	method_update;
 	char*	request_user_agent;
+        char*   request_user_header;
 	char*	request_serialize_callback;
 	char*	request_serialize_type;
 	char*	request_serialize_human_readable;
@@ -222,6 +224,7 @@ www_fdw_validator(PG_FUNCTION_ARGS)
 	char		*method_delete	= NULL;
 	char		*method_update	= NULL;
 	char		*request_user_agent= NULL;
+        char            *request_user_header = NULL;
 	char		*request_serialize_callback	= NULL;
 	char		*request_serialize_type	= NULL;
 	char		*request_serialize_human_readable	= NULL;
@@ -279,6 +282,7 @@ www_fdw_validator(PG_FUNCTION_ARGS)
 		if(parse_parameter("method_delete", &method_delete, def)) continue;
 		if(parse_parameter("method_update", &method_update, def)) continue;
 		if(parse_parameter("request_user_agent", &request_user_agent, def)) continue;
+                if(parse_parameter("request_user_header", &request_user_header, def)) continue;
 		if(parse_parameter("request_serialize_callback", &request_serialize_callback, def)) continue;
 		if(parse_parameter("request_serialize_type", &request_serialize_type, def)) continue;
 		if(parse_parameter("request_serialize_human_readable", &request_serialize_human_readable, def))
@@ -1398,6 +1402,7 @@ get_www_fdw_options(WWW_fdw_options *opts, Oid *opts_type, Datum *opts_value)
 		opts->method_update,
 
 		opts->request_user_agent,
+                opts->request_user_header,
 		opts->request_serialize_callback,
 		opts->request_serialize_type,
 		opts->request_serialize_human_readable,
@@ -1731,6 +1736,7 @@ www_begin(ForeignScanState *node, int eflags)
 	Datum			opts_value	= 0;
 	PostParameters	post;
 	struct curl_slist	*curl_opts = NULL;
+        int                     header_set = 0;
 
 	d("www_begin routine");
 
@@ -1779,6 +1785,10 @@ www_begin(ForeignScanState *node, int eflags)
 	curl = curl_easy_init();
 	curl_easy_setopt(curl, CURLOPT_URL, url.data);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, opts->request_user_agent);
+        if(opts->request_user_header)
+        {
+            curl_opts = curl_slist_append(curl_opts, opts->request_user_header);
+        }
 	curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_error_buffer);
 	if(post.post || 0 == strcmp(opts->method_select, "POST"))
 	{
@@ -1788,9 +1798,15 @@ www_begin(ForeignScanState *node, int eflags)
 			curl_opts = curl_slist_append(curl_opts, "Content-type:");
 			curl_opts = curl_slist_append(curl_opts, post.content_type.data);
 			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_opts);
+                        header_set = 1;
 		}
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, post.data.data);
 	}
+
+        if ((opts->request_user_header)&&(0 == header_set))
+        {
+            curl_easy_setopt(curl, CURLOPT_HTTPHEADER, curl_opts);
+        }
 
 	/* prepare parsers */
 	if( 0 == strcmp(opts->response_type, "json") )
@@ -2236,6 +2252,9 @@ get_options(Oid foreigntableid, WWW_fdw_options *opts)
 		if (strcmp(def->defname, "request_user_agent") == 0)
 			opts->request_user_agent	= defGetString(def);
 
+		if (strcmp(def->defname, "request_user_header") == 0)
+			opts->request_user_header	= defGetString(def);
+
 		if (strcmp(def->defname, "request_serialize_callback") == 0)
 			opts->request_serialize_callback	= defGetString(def);
 
@@ -2282,6 +2301,7 @@ get_options(Oid foreigntableid, WWW_fdw_options *opts)
 	if (!opts->method_update) opts->method_update	= "POST";
 
 	if (!opts->request_user_agent) opts->request_user_agent	= "www_fdw postgres extension";
+        if (!opts->request_user_header) opts->request_user_header = "";
 
 	if (!opts->request_serialize_type) opts->request_serialize_type	= "log";
 	if (!opts->request_serialize_human_readable) opts->request_serialize_human_readable	= "0";


### PR DESCRIPTION
During integration with Docplanner https://www.docplanner.com/about-us we need to add basic authorization header for HTTP Authorization.

There are two new options for this: username and password.